### PR TITLE
Add Dockerfile with Aliyun mirrors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+# Use Aliyun mirror for faster apt installs
+RUN sed -i 's|deb.debian.org|mirrors.aliyun.com|g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|mirrors.aliyun.com|g' /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get clean
+
+# Configure pip to use a mirror and install dependencies
+COPY pip.conf /etc/pip.conf
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+CMD ["uvicorn", "app.main:app"]
+


### PR DESCRIPTION
## Summary
- add Dockerfile
  - uses python:3.11-slim
  - switches apt sources to Aliyun mirror
  - copies pip.conf and requirements.txt
  - installs dependencies via pip
  - default command runs `uvicorn app.main:app`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864cc1c0a4c832cb6c356bbdbd3f446