### PR TITLE
Add FastAPI health route with SQLite init

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from sqlmodel import SQLModel, create_engine
+
+DATABASE_URL = "sqlite:///gift.db"
+engine = create_engine(DATABASE_URL, echo=False)
+
+app = FastAPI()
+
+@app.on_event("startup")
+def on_startup() -> None:
+    """Initialize database tables."""
+    SQLModel.metadata.create_all(engine)
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Health check endpoint."""
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- initialize FastAPI application at `app/main.py`
- connect SQLite `gift.db` via SQLModel and create tables on startup
- expose `/health` endpoint

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6864cd3c40e0832c9ffca25dcc656b9b