### PR TITLE
Add recommendation and PDF plan endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # AIgift_work
+
+## API Endpoints
+
+- `GET /health` - Simple health check.
+- `POST /recommend` - Provide `{"text": "...", "budget": 100}` and receive a list of up to five matching products.
+- `POST /plan` - Same payload as `/recommend` but returns a PDF file summarizing the recommended products.

--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,21 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from sqlmodel import SQLModel, create_engine
+from pydantic import BaseModel
+from reportlab.pdfgen import canvas
+import io
 
 from app.models import Product  # noqa: F401
+from app.recommendation import vector_search
 
 DATABASE_URL = "sqlite:///gift.db"
 engine = create_engine(DATABASE_URL, echo=False)
 
 app = FastAPI()
+
+
+class RecommendationRequest(BaseModel):
+    text: str
+    budget: float
 
 @app.on_event("startup")
 def on_startup() -> None:
@@ -17,3 +26,30 @@ def on_startup() -> None:
 def health() -> dict[str, str]:
     """Health check endpoint."""
     return {"status": "ok"}
+
+
+@app.post("/recommend")
+def recommend(req: RecommendationRequest) -> list[dict]:
+    """Return top 5 recommended products within the budget."""
+    return vector_search(req.text, req.budget, limit=5)
+
+
+@app.post("/plan")
+def plan(req: RecommendationRequest) -> Response:
+    """Generate a PDF plan of recommended products."""
+    products = vector_search(req.text, req.budget, limit=5)
+    buffer = io.BytesIO()
+    pdf = canvas.Canvas(buffer)
+    y = 800
+    pdf.setFont("Helvetica", 12)
+    pdf.drawString(50, y, "Gift Plan")
+    y -= 30
+    for p in products:
+        line = f"{p.get('name', '')} - ${p.get('price', 0)}"
+        pdf.drawString(50, y, line)
+        y -= 20
+    pdf.save()
+    pdf_bytes = buffer.getvalue()
+    buffer.close()
+    headers = {"Content-Disposition": "attachment; filename=plan.pdf"}
+    return Response(content=pdf_bytes, media_type="application/pdf", headers=headers)

--- a/app/recommendation.py
+++ b/app/recommendation.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import List
+
+import openai
+from qdrant_client import QdrantClient
+from qdrant_client.http import models as rest
+
+DATABASE_URL = "sqlite:///gift.db"
+QDRANT_URL = "http://localhost:6333"
+COLLECTION_NAME = "products"
+EMBED_DIM = 3072
+
+
+def embed_text(text: str) -> List[float]:
+    """Return embedding vector for a given text using OpenAI."""
+    response = openai.Embedding.create(model="text-embedding-3-large", input=text)
+    return response["data"][0]["embedding"]
+
+
+def vector_search(text: str, budget: float, limit: int = 5) -> List[dict]:
+    """Return top matching product payloads within the budget."""
+    client = QdrantClient(url=QDRANT_URL)
+    query_vector = embed_text(text)
+    search_result = client.search(
+        collection_name=COLLECTION_NAME,
+        query_vector=query_vector,
+        limit=limit,
+        with_payload=True,
+        query_filter=rest.Filter(
+            must=[rest.FieldCondition(key="price", range=rest.Range(lte=budget))]
+        ),
+    )
+    return [point.payload for point in search_result]


### PR DESCRIPTION
## Summary
- implement `vector_search` helper for qdrant
- add `/recommend` and `/plan` routes
- generate PDF plan using reportlab
- document new endpoints in README

## Testing
- `python -m py_compile app/main.py app/recommendation.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d02f1f18832c9486a421e7b8e23c